### PR TITLE
[T] Ignore dist/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 
 # Parcel cache
 .cache/
+
+# Parcel dist
+dist/


### PR DESCRIPTION
As for now on the website is available through `gh-pages` branch the `dist` folder is not necessary (before the website was available through `docs` folder).