### PR TITLE
Build project with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - run: cp CNAME dist/
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v2.5.0
+        env:
+          PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          PUBLISH_BRANCH: gh-pages
+          PUBLISH_DIR: ./dist


### PR DESCRIPTION
Hi! I stumbled upon issue #2 and took a stab at it.

This PR adds a workflow that builds the project and deploys it to GitHub Pages.

Note: Deploying to `gh-pages` branch requires an access token:
1. [Generate an access token](https://github.com/settings/tokens/new) with access to this repository.
2. [Add a new secret](https://github.com/viniciuskneves/ichbineinekartoffel.de/settings/secrets) to this repo with name `PERSONAL_TOKEN` and the access token as the value.

Resolves #2 